### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # OverscrollScale
 ListView overscroll scale
-##ScreenShot
+## ScreenShot
 ![](gif/demo.gif)
 
-##Use
+## Use
 
 ```groovy
 repositories {
@@ -24,7 +24,7 @@ dependencies {
         android:layout_height="match_parent" />
 ```
 
-##LICENSE
+## LICENSE
 
 
 The MIT License (MIT)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
